### PR TITLE
Update Inno Parameters Dynamically

### DIFF
--- a/.github/workflows/cd-windows.yml
+++ b/.github/workflows/cd-windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build Executable
       run: cd PandocGui && dotnet publish --output "c:/temp/pandocgui" --runtime win-x64 --configuration Release -p:PublishSingleFile=true --self-contained true
     - name: Compile Installer
-      run: iscc installer.iss /dBuildNumber=${{github.run_number}}
+      run: iscc installer.iss /dBuildNumber=${{github.run_number}} /dMyAppURL=https://github.com/${{github.repository}}
     - name: Save Installer as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/cd-windows.yml
+++ b/.github/workflows/cd-windows.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build Executable
       run: cd PandocGui && dotnet publish --output "c:/temp/pandocgui" --runtime win-x64 --configuration Release -p:PublishSingleFile=true --self-contained true
     - name: Compile Installer
-      run: iscc "installer.iss"
+      run: iscc installer.iss /dBuildNumber=${{github.run_number}}
     - name: Save Installer as Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/installer.iss
+++ b/installer.iss
@@ -1,6 +1,6 @@
 
 #define MyAppName "Pandoc GUI"
-#define MyAppVersion "1.0.2"
+#define MyAppVersion "1.1"
 #define MyAppPublisher "Arsene Lapostolet"
 #define MyAppURL "https://github.com/Ombrelin/pandoc-gui"
 #define MyAppExeName "PandocGui.exe"
@@ -8,7 +8,7 @@
 [Setup]
 AppId={{FCD2F146-6DB8-4DDC-AAA2-E9E5DA061AA6}
 AppName={#MyAppName}
-AppVersion={#MyAppVersion}
+AppVersion={#MyAppVersion}.{#BuildNumber}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}

--- a/installer.iss
+++ b/installer.iss
@@ -2,7 +2,6 @@
 #define MyAppName "Pandoc GUI"
 #define MyAppVersion "1.1"
 #define MyAppPublisher "Arsene Lapostolet"
-#define MyAppURL "https://github.com/Ombrelin/pandoc-gui"
 #define MyAppExeName "PandocGui.exe"
 
 [Setup]


### PR DESCRIPTION
* Resolves #19 

This sets the AppVersion in the Control Panel to be dynamic and based on the GitHub Actions run number. This also sets the help URL to be based on the repository that built the app to avoid any confusion if others create builds from their own forks

Tested with GitHub Actions - https://github.com/Trenly/pandoc-gui/actions/runs/1660845895