### PR TITLE
Support opening a file with Pandoc GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ riderModule.iml
 build-dir
 dist/
 
+#Visual Studio
+.vs/
+**/Properties/launchSettings.json

--- a/src/PandocGui/ViewModels/MainWindowViewModel.cs
+++ b/src/PandocGui/ViewModels/MainWindowViewModel.cs
@@ -77,6 +77,13 @@ public class MainWindowViewModel : ViewModelBase
         OpenLogFolderCommand = ReactiveCommand.Create(dataDirectoryService.OpenLogFolder);
 
         InstalledFonts = GetInstalledFonts();
+
+        //auto set SourcePath as the file user opened.
+        var args = Environment.GetCommandLineArgs();
+        if (args.Count() > 1 && File.Exists(args[1]))
+        {
+            this.SourcePath= args[1];
+        }
     }
 
     private static List<string> GetInstalledFonts() => SKFontManager.Default.FontFamilies.ToList();


### PR DESCRIPTION
When you right click a file in explorer and open it with Pandoc GUI, the file is autometically set as SourcePath.