### PR TITLE
Tests for MainWindowViewModel

### DIFF
--- a/src/PandocGui/App.axaml.cs
+++ b/src/PandocGui/App.axaml.cs
@@ -34,7 +34,7 @@ public class App : Application
                     new FileDialogService(desktop.MainWindow),
                     new PandocCli(),
                     dataDirService,
-                    desktop.MainWindow.Clipboard ?? throw new InvalidOperationException("No application clipboard")
+                    new ClipboardService(desktop.MainWindow.Clipboard ?? throw new InvalidOperationException("No application clipboard"))
                 );
         }
 

--- a/src/PandocGui/Services/ClipboardService.cs
+++ b/src/PandocGui/Services/ClipboardService.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Avalonia.Input.Platform;
+
+namespace PandocGui.Services;
+
+public class ClipboardService : IClipboardService
+{
+    private readonly IClipboard clipboard;
+
+    public ClipboardService(IClipboard clipboard)
+    {
+        this.clipboard = clipboard;
+    }
+
+    public Task SetTextAsync(string text) => clipboard.SetTextAsync(text);
+}

--- a/src/PandocGui/Services/IClipboardService.cs
+++ b/src/PandocGui/Services/IClipboardService.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace PandocGui.Services;
+
+public interface IClipboardService
+{
+    Task SetTextAsync(string text);
+}

--- a/src/PandocGui/ViewModels/MainWindowViewModel.cs
+++ b/src/PandocGui/ViewModels/MainWindowViewModel.cs
@@ -8,7 +8,6 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Avalonia.Input.Platform;
 using PandocGui.CliWrapper;
 using PandocGui.CliWrapper.Command;
 using PandocGui.Services;
@@ -59,12 +58,12 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IFileDialogService fileDialogService;
     private readonly IPandocCli pandoc;
     private readonly IDataDirectoryService dataDirectoryService;
-    private readonly IClipboard clipboard;
+    private readonly IClipboardService clipboard;
     private readonly ObservableAsPropertyHelper<bool> isExporting;
     public bool IsExporting => isExporting.Value;
 
     public MainWindowViewModel(IFileDialogService fileDialogService, IPandocCli pandoc,
-        IDataDirectoryService dataDirectoryService, IClipboard clipboard)
+        IDataDirectoryService dataDirectoryService, IClipboardService clipboard)
     {
         this.clipboard = clipboard;
         dataDirectoryService.EnsureCreated();

--- a/tests/PandocGui.Tests/Fakes/Fakes.cs
+++ b/tests/PandocGui.Tests/Fakes/Fakes.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using PandocGui.CliWrapper;
+using PandocGui.Services;
+
+namespace PandocGui.Tests.Fakes;
+
+public class FakeFileDialogService : IFileDialogService
+{
+    public string OpenFileResult { get; set; } = "";
+    public string SaveFileResult { get; set; } = "";
+
+    public Task<string> OpenFileAsync() => Task.FromResult(OpenFileResult);
+    public Task<string> SaveFileAsync() => Task.FromResult(SaveFileResult);
+}
+
+public class FakePandocCli : IPandocCli
+{
+    public PandocParameters LastParameters { get; private set; }
+    public Exception ExportException { get; set; }
+    public string Command { get; set; } = "-f markdown \"source.md\"";
+
+    public Task ExportPdfAsync(PandocParameters parameters)
+    {
+        LastParameters = parameters;
+        return ExportException is null ? Task.CompletedTask : Task.FromException(ExportException);
+    }
+
+    public string GetCommand(PandocParameters parameters)
+    {
+        LastParameters = parameters;
+        return Command;
+    }
+}
+
+public class FakeDataDirectoryService : IDataDirectoryService
+{
+    public int EnsureCreatedCalls { get; private set; }
+    public int OpenLogFolderCalls { get; private set; }
+
+    public void EnsureCreated() => EnsureCreatedCalls++;
+    public void OpenLogFolder() => OpenLogFolderCalls++;
+    public string GetPath() => "data";
+    public string GetLogsPath() => "data/logs";
+}
+
+public class FakeClipboardService : IClipboardService
+{
+    public string LastText { get; private set; }
+
+    public Task SetTextAsync(string text)
+    {
+        LastText = text;
+        return Task.CompletedTask;
+    }
+}

--- a/tests/PandocGui.Tests/MainWindowViewModelTest.cs
+++ b/tests/PandocGui.Tests/MainWindowViewModelTest.cs
@@ -1,0 +1,265 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using PandocGui.CliWrapper;
+using PandocGui.Tests.Fakes;
+using PandocGui.ViewModels;
+using Xunit;
+
+namespace PandocGui.Tests;
+
+public class MainWindowViewModelTest
+{
+    private readonly FakeFileDialogService fileDialog = new();
+    private readonly FakePandocCli pandoc = new();
+    private readonly FakeDataDirectoryService dataDirectory = new();
+    private readonly FakeClipboardService clipboard = new();
+
+    private MainWindowViewModel BuildViewModel() =>
+        new(fileDialog, pandoc, dataDirectory, clipboard);
+
+    [Fact]
+    public void NewViewModel_StartsEmptyWithDefaultFormats()
+    {
+        // When
+        var viewModel = BuildViewModel();
+
+        // Then
+        Assert.Equal("", viewModel.SourcePath);
+        Assert.Equal("", viewModel.TargetPath);
+        Assert.Equal(PandocFormats.DefaultInputFormat, viewModel.SourceFormat);
+        Assert.Equal(PandocFormats.OutputFormats[0], viewModel.SelectedOutputFormat);
+        Assert.Equal(1, dataDirectory.EnsureCreatedCalls);
+    }
+
+    [Theory]
+    [InlineData("report.md", "markdown")]
+    [InlineData("paper.docx", "docx")]
+    [InlineData("page.HTML", "html")]
+    [InlineData("thesis.tex", "latex")]
+    [InlineData("archive.unknown", "markdown")]
+    public void SettingSourcePath_DetectsInputFormat(string fileName, string expectedFormat)
+    {
+        // Given
+        var viewModel = BuildViewModel();
+
+        // When
+        viewModel.SourcePath = Path.Combine("documents", fileName);
+
+        // Then
+        Assert.Equal(expectedFormat, viewModel.SourceFormat);
+    }
+
+    [Fact]
+    public void SettingSourcePath_FillsTargetPathWithSelectedOutputExtension()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+
+        // When
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "report.pdf"), viewModel.TargetPath);
+    }
+
+    [Fact]
+    public void SettingSourcePath_ToBlank_LeavesTargetPathUntouched()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+
+        // When
+        viewModel.SourcePath = "";
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "report.pdf"), viewModel.TargetPath);
+        Assert.Equal("markdown", viewModel.SourceFormat);
+    }
+
+    [Fact]
+    public void ChangingOutputFormat_SwapsTargetExtensionKeepingFolderAndName()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+
+        // When
+        viewModel.SelectedOutputFormat = PandocFormats.OutputFormats.First(format => format.Extension == ".html");
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "report.html"), viewModel.TargetPath);
+    }
+
+    [Fact]
+    public void ChangingOutputFormat_WithoutTargetPath_FillsItFromSourcePath()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+        viewModel.TargetPath = "";
+
+        // When
+        viewModel.SelectedOutputFormat = PandocFormats.OutputFormats.First(format => format.Extension == ".epub");
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "report.epub"), viewModel.TargetPath);
+    }
+
+    [Theory]
+    [InlineData("", "", false)]
+    [InlineData("source.md", "", false)]
+    [InlineData("", "target.pdf", false)]
+    [InlineData("source.md", "target.pdf", true)]
+    public async Task ExportCommand_IsEnabledOnlyWithBothPaths(string source, string target, bool expected)
+    {
+        // Given
+        var viewModel = BuildViewModel();
+
+        // When
+        viewModel.SourcePath = source;
+        viewModel.TargetPath = target;
+
+        // Then
+        Assert.Equal(expected, await viewModel.ExportCommand.CanExecute.FirstAsync());
+    }
+
+    [Fact]
+    public async Task ExportCommand_WhenPandocFails_ReportsTheError()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+        pandoc.ExportException = new InvalidOperationException("pandoc exploded");
+
+        // When
+        await viewModel.ExportCommand.Execute();
+
+        // Then
+        Assert.True(viewModel.IsError);
+        Assert.Equal("pandoc exploded", viewModel.Result);
+    }
+
+    [Fact]
+    public async Task CopyCommand_PutsTheFullPandocCommandOnTheClipboard()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        pandoc.Command = "-f docx \"paper.docx\"";
+
+        // When
+        await viewModel.CopyCommand.Execute();
+
+        // Then
+        Assert.Equal("pandoc -f docx \"paper.docx\"", clipboard.LastText);
+    }
+
+    [Fact]
+    public async Task CopyCommand_BuildsParametersFromTheCurrentSelection()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "paper.docx");
+        viewModel.NumberedHeadersEnabled = true;
+        viewModel.TableOfContentEnabled = true;
+
+        // When
+        await viewModel.CopyCommand.Execute();
+
+        // Then
+        var parameters = pandoc.LastParameters;
+        Assert.Equal(Path.Combine("documents", "paper.docx"), parameters.SourcePath);
+        Assert.Equal(Path.Combine("documents", "paper.pdf"), parameters.TargetPath);
+        Assert.Equal("docx", parameters.SourceFormat);
+        Assert.True(parameters.NumberedHeader);
+        Assert.True(parameters.TableOfContents);
+        Assert.StartsWith(dataDirectory.GetLogsPath(), parameters.LogFilePath);
+    }
+
+    [Fact]
+    public async Task SearchSourceFileCommand_TakesThePathFromTheFileDialog()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        fileDialog.OpenFileResult = Path.Combine("documents", "notes.rst");
+
+        // When
+        await viewModel.SearchSourceFileCommand.Execute();
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "notes.rst"), viewModel.SourcePath);
+        Assert.Equal("rst", viewModel.SourceFormat);
+    }
+
+    [Fact]
+    public async Task SearchTargetFileCommand_TakesThePathFromTheFileDialog()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        fileDialog.SaveFileResult = Path.Combine("documents", "notes.epub");
+
+        // When
+        await viewModel.SearchTargetFileCommand.Execute();
+
+        // Then
+        Assert.Equal(Path.Combine("documents", "notes.epub"), viewModel.TargetPath);
+    }
+
+    [Fact]
+    public async Task ClearCommand_ResetsEveryOption()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        viewModel.SourcePath = Path.Combine("documents", "paper.docx");
+        viewModel.SelectedOutputFormat = PandocFormats.OutputFormats.First(format => format.Extension == ".html");
+        viewModel.CustomHighlightThemeEnabled = true;
+        viewModel.CustomHighlightThemeSource = "theme.theme";
+        viewModel.NumberedHeadersEnabled = true;
+        viewModel.CustomFontEnabled = true;
+        viewModel.CustomFontName = "Arial";
+        viewModel.CustomMarginEnabled = true;
+        viewModel.CustomMarginValue = 2.5m;
+        viewModel.CustomPdfEngineEnabled = true;
+        viewModel.CustomPdfEngineValue = "xelatex";
+        viewModel.TableOfContentEnabled = true;
+        viewModel.Result = "Success";
+        viewModel.IsError = true;
+
+        // When
+        await viewModel.ClearCommand.Execute();
+
+        // Then
+        Assert.Equal("", viewModel.SourcePath);
+        Assert.Equal("", viewModel.TargetPath);
+        Assert.Equal(PandocFormats.DefaultInputFormat, viewModel.SourceFormat);
+        Assert.Equal(PandocFormats.OutputFormats[0], viewModel.SelectedOutputFormat);
+        Assert.Equal("", viewModel.Result);
+        Assert.False(viewModel.IsError);
+        Assert.False(viewModel.CustomHighlightThemeEnabled);
+        Assert.Equal("", viewModel.CustomHighlightThemeSource);
+        Assert.False(viewModel.NumberedHeadersEnabled);
+        Assert.False(viewModel.CustomFontEnabled);
+        Assert.Equal("", viewModel.CustomFontName);
+        Assert.False(viewModel.CustomMarginEnabled);
+        Assert.Equal(1.3m, viewModel.CustomMarginValue);
+        Assert.False(viewModel.CustomPdfEngineEnabled);
+        Assert.Equal("", viewModel.CustomPdfEngineValue);
+        Assert.False(viewModel.TableOfContentEnabled);
+    }
+
+    [Fact]
+    public void OpenLogFolderCommand_AsksTheDataDirectoryService()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+
+        // When
+        viewModel.OpenLogFolderCommand.Execute().Subscribe();
+
+        // Then
+        Assert.Equal(1, dataDirectory.OpenLogFolderCalls);
+    }
+}

--- a/tests/PandocGui.Tests/PandocGui.Tests.csproj
+++ b/tests/PandocGui.Tests/PandocGui.Tests.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\PandocGui.CliWrapper\PandocGui.CliWrapper.csproj" />
+        <ProjectReference Include="..\..\src\PandocGui\PandocGui.csproj" />
     </ItemGroup>
 
 </Project>

--- a/tests/PandocGui.Tests/ReactiveUiTestHost.cs
+++ b/tests/PandocGui.Tests/ReactiveUiTestHost.cs
@@ -1,0 +1,23 @@
+using System.Reactive.Concurrency;
+using System.Runtime.CompilerServices;
+using ReactiveUI.Builder;
+
+namespace PandocGui.Tests;
+
+/// <summary>
+/// The app initializes ReactiveUI through Avalonia (<c>UseReactiveUI</c> in <c>Program</c>), which never
+/// runs in a test host, and ReactiveUI throws on first use when it has not been initialized. This does the
+/// same job for the test assembly, and pins both schedulers to the immediate one so commands and
+/// <c>ToProperty</c> pipelines run synchronously inside a test.
+/// </summary>
+internal static class ReactiveUiTestHost
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        var builder = RxAppBuilder.CreateReactiveUIBuilder();
+        builder.WithMainThreadScheduler(ImmediateScheduler.Instance);
+        builder.WithTaskPoolScheduler(ImmediateScheduler.Instance);
+        builder.Build();
+    }
+}


### PR DESCRIPTION
You mentioned you wanted tests for `MainWindowViewModel` - here they are, so you do not have to write them yourself. This slots in before the UI redesign, since that PR touches the same view model and it is nicer to have it pinned first.

## What was needed to get there

Three things stood in the way, and I kept each as small as I could:

1. **The test project only referenced `PandocGui.CliWrapper`.** It now also references the app project.
2. **ReactiveUI is initialized through Avalonia** (`UseReactiveUI` in `Program.BuildAvaloniaApp`), which never runs in a test host - ReactiveUI 23 throws `ReactiveUI has not been initialized` on the first `WhenAnyValue`. `ReactiveUiTestHost` does the same job for the test assembly via `RxAppBuilder`, in a `[ModuleInitializer]`, and pins both schedulers to `ImmediateScheduler` so commands and `ToProperty` pipelines run synchronously inside a test.
3. **`CopyCommand` was untestable.** Avalonia 12's `IClipboard` is explicitly not implementable by user code (the compiler rejects any implementation), so it cannot be faked or mocked. I put a one-method `IClipboardService` in front of it, with `ClipboardService` wrapping the real Avalonia clipboard and `App` doing the wrapping. That is the only production change of substance in this PR - happy to drop it and the two clipboard tests with it if you would rather keep the view model on `IClipboard`.

No new NuGet packages: the fakes are four small hand-written classes, since `NSubstitute` only arrives with the test-infrastructure PR later in the sequence. Same xUnit style as the existing suite for the same reason.

## What is covered

21 tests, 46 in the suite overall:

- initial state (empty paths, `markdown`, PDF selected, data directory created)
- extension to pandoc reader detection, including an unknown extension and a mixed-case one
- target autofill from the source path, and that blanking the source does not wipe the target
- swapping the output format rewrites the target extension and keeps folder and file name
- swapping the output format with an empty target refills it from the source
- export gating: enabled only once both paths are set
- the `PandocParameters` the view model builds (paths, source format, options, log path)
- both file-dialog commands
- error reporting when pandoc throws
- `Clear` resetting every option

I sanity-checked them by mutation: breaking the extension swap, the export gating and `Clear` in turn each turns the matching tests red.

## Known gap

`Export`'s success path is not covered. On success the view model calls `Process.Start` on the target file, which in a test either fails or actually opens a document. The parameter-building assertions therefore go through `CopyCommand`, which builds the same `PandocParameters`. If you want that path covered too, the fix is another small seam (an injected "open the result" action) - tell me and I will add it, or leave it as is.
