### PR TITLE
UI redesign: progressive single page with drag & drop (4/13)

### DIFF
--- a/src/PandocGui.CliWrapper/PandocFormats.cs
+++ b/src/PandocGui.CliWrapper/PandocFormats.cs
@@ -5,7 +5,10 @@ using System.Linq;
 
 namespace PandocGui.CliWrapper;
 
-public record OutputFormat(string DisplayName, string Extension);
+public record OutputFormat(string DisplayName, string Extension)
+{
+    public override string ToString() => DisplayName;
+}
 
 public static class PandocFormats
 {

--- a/src/PandocGui/Program.cs
+++ b/src/PandocGui/Program.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System;
+using Avalonia;
 using ReactiveUI.Avalonia;
 
 namespace PandocGui;
@@ -8,6 +9,10 @@ class Program
     // Initialization code. Don't use any Avalonia, third-party APIs or any
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
+    //
+    // [STAThread] is required on Windows for native OLE drag-and-drop (RegisterDragDrop needs an
+    // STA thread) - without it the window silently never becomes a drop target.
+    [STAThread]
     public static void Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);
 

--- a/src/PandocGui/ViewModels/MainWindowViewModel.cs
+++ b/src/PandocGui/ViewModels/MainWindowViewModel.cs
@@ -61,6 +61,10 @@ public partial class MainWindowViewModel : ViewModelBase
     private readonly IClipboardService clipboard;
     private readonly ObservableAsPropertyHelper<bool> isExporting;
     public bool IsExporting => isExporting.Value;
+    private readonly ObservableAsPropertyHelper<bool> hasInput;
+    public bool HasInput => hasInput.Value;
+    private readonly ObservableAsPropertyHelper<bool> isStatusVisible;
+    public bool IsStatusVisible => isStatusVisible.Value;
 
     public MainWindowViewModel(IFileDialogService fileDialogService, IPandocCli pandoc,
         IDataDirectoryService dataDirectoryService, IClipboardService clipboard)
@@ -93,6 +97,13 @@ public partial class MainWindowViewModel : ViewModelBase
         ExportCommand.IsExecuting.ToProperty(this, x => x.IsExporting, out isExporting);
         SearchHighlightThemeSourceCommand = ReactiveCommand.CreateFromTask(SearchHighlightThemeSource);
         OpenLogFolderCommand = ReactiveCommand.Create(dataDirectoryService.OpenLogFolder);
+
+        this.WhenAnyValue(x => x.SourcePath)
+            .Select(path => !string.IsNullOrWhiteSpace(path))
+            .ToProperty(this, x => x.HasInput, out hasInput);
+        this.WhenAnyValue(x => x.Result)
+            .Select(result => !string.IsNullOrWhiteSpace(result))
+            .ToProperty(this, x => x.IsStatusVisible, out isStatusVisible);
 
         this.WhenAnyValue(x => x.SourcePath)
             .Subscribe(path =>

--- a/src/PandocGui/Views/MainWindow.axaml
+++ b/src/PandocGui/Views/MainWindow.axaml
@@ -13,6 +13,17 @@
         DragDrop.AllowDrop="True"
         Title="PandocGui">
 
+    <Window.Styles>
+        <!-- Without an explicit item template a ComboBox renders its selection blank. -->
+        <Style Selector="ComboBox">
+            <Setter Property="ItemTemplate">
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" />
+                </DataTemplate>
+            </Setter>
+        </Style>
+    </Window.Styles>
+
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="File">

--- a/src/PandocGui/Views/MainWindow.axaml
+++ b/src/PandocGui/Views/MainWindow.axaml
@@ -1,21 +1,17 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="using:PandocGui.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ui="using:FluentAvalonia.UI.Controls"
         xmlns:avaloniaProgressRing="clr-namespace:AvaloniaProgressRing;assembly=AvaloniaProgressRing"
         mc:Ignorable="d"
-        Width="700" Height="800"
-        MinWidth="350"
+        Width="640" Height="600"
+        MinWidth="480" MinHeight="480"
         WindowStartupLocation="CenterScreen"
         x:Class="PandocGui.Views.MainWindow"
         Icon="/Assets/avalonia-logo.ico"
+        DragDrop.AllowDrop="True"
         Title="PandocGui">
-
-    <Design.DataContext>
-        <vm:MainWindowViewModel />
-    </Design.DataContext>
-
 
     <DockPanel>
         <Menu DockPanel.Dock="Top">
@@ -23,178 +19,114 @@
                 <MenuItem x:Name="openLogFolderMenu" Header="Open logs folder" />
             </MenuItem>
         </Menu>
-        <Border DockPanel.Dock="Bottom" Padding="16">
-            <StackPanel>
-                <Grid Height="550">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition />
-                    </Grid.ColumnDefinitions>
-                    <Border Padding="8">
-                        <StackPanel Spacing="8">
-                            <TextBlock>Input file :</TextBlock>
-                            <StackPanel
-                                HorizontalAlignment="Center"
-                                Orientation="Horizontal"
-                                Spacing="16">
 
-                                <TextBox Width="200" x:Name="searchSourceFileInput" />
-                                <Button x:Name="searchSourceFileButton">
-                                    <TextBlock Text="Search File" />
-                                </Button>
-                            </StackPanel>
-                        </StackPanel>
-                    </Border>
-                    <Border Padding="8" Grid.Column="1" Grid.Row="0">
-                        <StackPanel Spacing="8">
+        <Panel Margin="24">
 
-                            <TextBlock>Output file :</TextBlock>
-                            <StackPanel
-                                HorizontalAlignment="Center"
-                                Orientation="Horizontal"
-                                Spacing="16">
-                                <TextBox Width="200" x:Name="searchTargetFileInput" />
-                                <Button x:Name="searchTargetFileButton">
-                                    <TextBlock Text="Search File" />
-                                </Button>
-                            </StackPanel>
-                        </StackPanel>
-                    </Border>
-                    <Expander Header="Code Highlight" Grid.Column="1" Grid.Row="1">
-                        <StackPanel HorizontalAlignment="Center">
-                            <Grid>
-                                <Grid.ColumnDefinitions>2*,*,*</Grid.ColumnDefinitions>
-                                <TextBlock VerticalAlignment="Center">Code Highlight Theme :</TextBlock>
-                                <ToggleSwitch Grid.Column="2"
-                                              x:Name="highlightToggle" />
-                            </Grid>
-
-                            <StackPanel
-                                HorizontalAlignment="Center"
-                                Orientation="Horizontal"
-                                Spacing="16">
-                                <TextBox Width="200" x:Name="highlightFileInput" />
-                                <Button x:Name="highlightFileButton">
-                                    <TextBlock Text="Search File" />
-                                </Button>
-                            </StackPanel>
-                        </StackPanel>
-                    </Expander>
-                    <Expander Header="Document Content" Grid.Row="1" Grid.Column="0">
-
-                        <StackPanel>
-                            <Grid Width="305">
-                                <Grid.RowDefinitions>*,*,*,*</Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>2*,*,*</Grid.ColumnDefinitions>
-                                <TextBlock VerticalAlignment="Center">Headers Numbering :</TextBlock>
-                                <ToggleSwitch Grid.Column="2"
-                                              x:Name="headersNumberingToggle" />
-                                
-                                <TextBlock Grid.Row="1" VerticalAlignment="Center">Table of Content :</TextBlock>
-                                <ToggleSwitch Grid.Column="2" Grid.Row="1"
-                                              x:Name="contentTableToggle" />
-                        
-                                <TextBlock Grid.Row="2" VerticalAlignment="Center">Custom Font :</TextBlock>
-                                <ToggleSwitch Grid.Column="2" Grid.Row="2"
-                                              x:Name="customFontToggle" />
-                          
-                                <TextBlock Grid.Row="3" HorizontalAlignment="Left" VerticalAlignment="Center">Custom Font Name :</TextBlock>
-                                <ComboBox Grid.Column="1" Grid.ColumnSpan="2" Grid.Row="3" Width="150" x:Name="fontNameCombobox">
-                                    <ComboBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding}" />
-                                        </DataTemplate>
-                                    </ComboBox.ItemTemplate>
-                                </ComboBox>
-                            </Grid>
-                        </StackPanel>
-                    </Expander>
-                    <Expander Header="Document Geometry" Grid.Row="2" Grid.Column="0">
-                        <StackPanel Spacing="16">
-                            <Grid Width="305">
-                                <TextBlock VerticalAlignment="Center">Custom Margin :</TextBlock>
-                                <ToggleSwitch VerticalAlignment="Center" HorizontalAlignment="Right"
-                                              x:Name="customMarginToggle" />
-                            </Grid>
-                            <StackPanel HorizontalAlignment="Center" Spacing="16" Orientation="Horizontal">
-                                <NumericUpDown Width="275" VerticalAlignment="Center" Value="1.3" Increment="0.1"
-                                               Minimum="0"
-                                               Maximum="10"
-                                               x:Name="customMarginInput" />
-                                <TextBlock VerticalAlignment="Center" HorizontalAlignment="Right"> cm</TextBlock>
-                            </StackPanel>
-                        </StackPanel>
-                    </Expander>
-                    <Expander Header="File Processing" Grid.Row="2" Grid.Column="1">
-                        <StackPanel>
-                            <StackPanel Spacing="16">
-                                <Grid Width="305">
-                                    <TextBlock VerticalAlignment="Center">Custom PDF Engine :</TextBlock>
-                                    <ToggleSwitch VerticalAlignment="Center" HorizontalAlignment="Right"
-                                                  x:Name="pdfEngineToggle" />
-                                </Grid>
-                                <ComboBox HorizontalAlignment="Center" Width="305" x:Name="pdfEngineCombobox">
-                                    <ComboBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding}" />
-                                        </DataTemplate>
-                                    </ComboBox.ItemTemplate>
-                                </ComboBox>
-                            </StackPanel>
-                        </StackPanel>
-                    </Expander>
-                </Grid>
-                <StackPanel Spacing="16" HorizontalAlignment="Center">
-                    <TextBlock
-
-                        x:Name="resultText"
-                        HorizontalAlignment="Center" />
-                    <Button
-                        x:Name="exportButton"
-                        HorizontalAlignment="Center"
-                        HorizontalContentAlignment="Center"
-                        VerticalAlignment="Bottom"
-                        Background="#0066CC">
-                        <TextBlock TextAlignment="Center" Width="305" Text="Export" />
-                    </Button>
-                    <avaloniaProgressRing:ProgressRing
-                        x:Name="loader"
-                        DockPanel.Dock="Bottom"
-                        Width="35"
-                        Height="35"
-                        IsActive="True"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Bottom"
-                        Foreground="#0066CC" />
-                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center"
-                                VerticalAlignment="Bottom">
-                        <Button
-                            x:Name="clearButton">
-                            <TextBlock TextAlignment="Center" Width="136" Text="Clear" />
-                        </Button>
-                        <Button
-                            x:Name="copyCommandButton">
-                            <TextBlock TextAlignment="Center" Width="136" Text="Copy Command" />
-                        </Button>
-                    </StackPanel>
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="8">
-                            <TextBlock VerticalAlignment="Center">Open file on completion :    </TextBlock>
-                            <ToggleSwitch VerticalAlignment="Center"
-                                          x:Name="openOnCompletionToggle" />
-                        </StackPanel>
-                    </StackPanel>
+            <!-- EMPTY STATE: guiding drop zone -->
+            <Border x:Name="emptyStatePanel"
+                    Background="#0AFFFFFF"
+                    BorderBrush="#33808080"
+                    BorderThickness="2"
+                    CornerRadius="8"
+                    Padding="32">
+                <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="14">
+                    <TextBlock Text="&#x1F4C4;" FontSize="48" HorizontalAlignment="Center" />
+                    <TextBlock Text="Drop a document here" FontSize="18" HorizontalAlignment="Center" />
+                    <TextBlock Text="or" Opacity="0.6" HorizontalAlignment="Center" />
+                    <Button x:Name="browseSourceEmptyButton" Content="Browse&#x2026;"
+                            HorizontalAlignment="Center" />
+                    <TextBlock Text="Supported: Markdown, Word, HTML, reStructuredText, LaTeX, EPUB, ODT and more"
+                               Opacity="0.6" TextWrapping="Wrap" TextAlignment="Center" MaxWidth="360" />
                 </StackPanel>
-                
+            </Border>
 
-            </StackPanel>
-        </Border>
+            <!-- LOADED STATE: convert form -->
+            <DockPanel x:Name="loadedStatePanel">
+
+                <StackPanel DockPanel.Dock="Bottom" Spacing="12">
+                    <ui:FAInfoBar x:Name="statusBar" IsClosable="False" />
+                    <Panel>
+                        <Button x:Name="exportButton" Classes="accent"
+                                Content="Convert"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Center" />
+                        <avaloniaProgressRing:ProgressRing x:Name="loader"
+                                Width="26" Height="26" IsActive="True"
+                                HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Panel>
+                    <Grid ColumnDefinitions="Auto,Auto,*,Auto">
+                        <Button x:Name="clearButton" Grid.Column="0" Content="Clear" Margin="0,0,8,0" />
+                        <Button x:Name="copyCommandButton" Grid.Column="1" Content="Copy command" />
+                        <ToggleSwitch x:Name="openOnCompletionToggle" Grid.Column="3"
+                                      Content="Open on completion" />
+                    </Grid>
+                </StackPanel>
+
+                <ScrollViewer>
+                    <StackPanel Spacing="8">
+
+                        <TextBlock Text="From" FontWeight="SemiBold" />
+                        <Grid ColumnDefinitions="*,140,Auto">
+                            <TextBox x:Name="searchSourceFileInput" Grid.Column="0" Margin="0,0,8,0" />
+                            <ComboBox x:Name="inputFormatCombo" Grid.Column="1" Margin="0,0,8,0"
+                                      HorizontalAlignment="Stretch" />
+                            <Button x:Name="searchSourceFileButton" Grid.Column="2" Content="Browse&#x2026;" />
+                        </Grid>
+
+                        <TextBlock Text="To" FontWeight="SemiBold" Margin="0,8,0,0" />
+                        <Grid ColumnDefinitions="*,140,Auto">
+                            <TextBox x:Name="searchTargetFileInput" Grid.Column="0" Margin="0,0,8,0" />
+                            <ComboBox x:Name="outputFormatCombo" Grid.Column="1" Margin="0,0,8,0"
+                                      HorizontalAlignment="Stretch" />
+                            <Button x:Name="searchTargetFileButton" Grid.Column="2" Content="Browse&#x2026;" />
+                        </Grid>
+
+                        <Expander Header="More options" Margin="0,12,0,0" HorizontalAlignment="Stretch">
+                            <StackPanel Spacing="12" Margin="0,8,0,0">
+
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Code highlight theme" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="highlightToggle" Grid.Column="1" />
+                                </Grid>
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBox x:Name="highlightFileInput" Grid.Column="0" Margin="0,0,8,0"
+                                             PlaceholderText="Theme file (.theme)" />
+                                    <Button x:Name="highlightFileButton" Grid.Column="1" Content="Browse&#x2026;" />
+                                </Grid>
+
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Headers numbering" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="headersNumberingToggle" Grid.Column="1" />
+                                </Grid>
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Table of contents" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="contentTableToggle" Grid.Column="1" />
+                                </Grid>
+
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Custom font" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="customFontToggle" Grid.Column="1" />
+                                </Grid>
+                                <ComboBox x:Name="fontNameCombobox" HorizontalAlignment="Stretch" />
+
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Custom margin (cm)" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="customMarginToggle" Grid.Column="1" />
+                                </Grid>
+                                <NumericUpDown x:Name="customMarginInput" Increment="0.1"
+                                               Minimum="0" Maximum="10" HorizontalAlignment="Stretch" />
+
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <TextBlock Text="Custom PDF engine" VerticalAlignment="Center" />
+                                    <ToggleSwitch x:Name="pdfEngineToggle" Grid.Column="1" />
+                                </Grid>
+                                <ComboBox x:Name="pdfEngineCombobox" HorizontalAlignment="Stretch" />
+
+                            </StackPanel>
+                        </Expander>
+                    </StackPanel>
+                </ScrollViewer>
+            </DockPanel>
+        </Panel>
     </DockPanel>
-
 </Window>

--- a/src/PandocGui/Views/MainWindow.axaml.cs
+++ b/src/PandocGui/Views/MainWindow.axaml.cs
@@ -1,197 +1,175 @@
+using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using Avalonia.Controls;
-using Avalonia.Media;
-using ReactiveUI.Avalonia;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
 using AvaloniaProgressRing;
+using FluentAvalonia.UI.Controls;
 using PandocGui.ViewModels;
 using ReactiveUI;
+using ReactiveUI.Avalonia;
 
 namespace PandocGui.Views;
 
 public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
+    private Border EmptyStatePanel => this.FindControl<Border>("emptyStatePanel")!;
+    private DockPanel LoadedStatePanel => this.FindControl<DockPanel>("loadedStatePanel")!;
+    private Button BrowseSourceEmptyButton => this.FindControl<Button>("browseSourceEmptyButton")!;
+
     private TextBox SearchSourceFileInput => this.FindControl<TextBox>("searchSourceFileInput")!;
+    private ComboBox InputFormatComboBox => this.FindControl<ComboBox>("inputFormatCombo")!;
     private Button SearchSourceFileButton => this.FindControl<Button>("searchSourceFileButton")!;
 
     private TextBox SearchTargetFileInput => this.FindControl<TextBox>("searchTargetFileInput")!;
+    private ComboBox OutputFormatComboBox => this.FindControl<ComboBox>("outputFormatCombo")!;
     private Button SearchTargetFileButton => this.FindControl<Button>("searchTargetFileButton")!;
+
     private Button ExportButton => this.FindControl<Button>("exportButton")!;
+    private ProgressRing Loader => this.FindControl<ProgressRing>("loader")!;
     private Button ClearButton => this.FindControl<Button>("clearButton")!;
     private Button CopyButton => this.FindControl<Button>("copyCommandButton")!;
-    private ProgressRing Loader => this.FindControl<ProgressRing>("loader")!;
+    private ToggleSwitch OpenOnCompletionToggle => this.FindControl<ToggleSwitch>("openOnCompletionToggle")!;
+    private FAInfoBar StatusBar => this.FindControl<FAInfoBar>("statusBar")!;
 
     private ToggleSwitch HighlightEnabledToggle => this.FindControl<ToggleSwitch>("highlightToggle")!;
-    private ToggleSwitch HeaderNumberingEnabledToggle => this.FindControl<ToggleSwitch>("headersNumberingToggle")!;
     private TextBox HighlightFileInput => this.FindControl<TextBox>("highlightFileInput")!;
     private Button HighlightFileButton => this.FindControl<Button>("highlightFileButton")!;
-
+    private ToggleSwitch HeaderNumberingEnabledToggle => this.FindControl<ToggleSwitch>("headersNumberingToggle")!;
+    private ToggleSwitch ContentTableToggle => this.FindControl<ToggleSwitch>("contentTableToggle")!;
     private ToggleSwitch CustomFontEnabledToggle => this.FindControl<ToggleSwitch>("customFontToggle")!;
-
     private ComboBox CustomFontNameComboBox => this.FindControl<ComboBox>("fontNameCombobox")!;
     private ToggleSwitch CustomMarginEnabledToggle => this.FindControl<ToggleSwitch>("customMarginToggle")!;
     private NumericUpDown CustomMarginValueInput => this.FindControl<NumericUpDown>("customMarginInput")!;
-    private ComboBox PdfEngineCombobox => this.FindControl<ComboBox>("pdfEngineCombobox")!;
     private ToggleSwitch PdfEngineToggle => this.FindControl<ToggleSwitch>("pdfEngineToggle")!;
-    private ToggleSwitch ContentTableToggle => this.FindControl<ToggleSwitch>("contentTableToggle")!;
-    private TextBlock ResultText => this.FindControl<TextBlock>("resultText")!;
+    private ComboBox PdfEngineCombobox => this.FindControl<ComboBox>("pdfEngineCombobox")!;
     private MenuItem OpenLogFolderMenu => this.FindControl<MenuItem>("openLogFolderMenu")!;
-    private ToggleSwitch OpenOnCompletionToggle => this.FindControl<ToggleSwitch>("openOnCompletionToggle")!;
 
     public MainWindow()
     {
         InitializeComponent();
+
+        AddHandler(DragDrop.DragOverEvent, OnDragOver);
+        AddHandler(DragDrop.DropEvent, OnDrop);
+
         this.WhenActivated((CompositeDisposable disposable) =>
         {
-            this.Bind(ViewModel,
-                vm => vm.SourcePath,
-                v => v.SearchSourceFileInput.Text
-            ).DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.HasInput, v => v.LoadedStatePanel.IsVisible)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.HasInput, v => v.EmptyStatePanel.IsVisible, hasInput => !hasInput)
+                .DisposeWith(disposable);
 
-            this.BindCommand(ViewModel,
-                vm => vm.SearchSourceFileCommand,
-                v => v.SearchSourceFileButton
-            ).DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.SearchSourceFileCommand, v => v.BrowseSourceEmptyButton)
+                .DisposeWith(disposable);
 
-            this.Bind(ViewModel,
-                vm => vm.TargetPath,
-                v => v.SearchTargetFileInput.Text
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.SourcePath, v => v.SearchSourceFileInput.Text)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.SupportedInputFormats, v => v.InputFormatComboBox.ItemsSource)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.SourceFormat, v => v.InputFormatComboBox.SelectedItem)
+                .DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.SearchSourceFileCommand, v => v.SearchSourceFileButton)
+                .DisposeWith(disposable);
 
-            this.BindCommand(ViewModel,
-                vm => vm.SearchTargetFileCommand,
-                v => v.SearchTargetFileButton
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.TargetPath, v => v.SearchTargetFileInput.Text)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.SupportedOutputFormats, v => v.OutputFormatComboBox.ItemsSource)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.SelectedOutputFormat, v => v.OutputFormatComboBox.SelectedItem)
+                .DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.SearchTargetFileCommand, v => v.SearchTargetFileButton)
+                .DisposeWith(disposable);
 
-            this.BindCommand(ViewModel,
-                vm => vm.ExportCommand,
-                v => v.ExportButton
-            ).DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.ExportCommand, v => v.ExportButton)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.IsExporting, v => v.Loader.IsVisible)
+                .DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.ClearCommand, v => v.ClearButton)
+                .DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.CopyCommand, v => v.CopyButton)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.OpenFileOnCompletion, v => v.OpenOnCompletionToggle.IsChecked)
+                .DisposeWith(disposable);
 
-            this.BindCommand(ViewModel,
-                vm => vm.ClearCommand,
-                v => v.ClearButton
-            ).DisposeWith(disposable);
-            this.BindCommand(ViewModel,
-                vm => vm.CopyCommand,
-                v => v.CopyButton
-            ).DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.IsStatusVisible, v => v.StatusBar.IsOpen)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.Result, v => v.StatusBar.Message)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.IsError, v => v.StatusBar.Severity, ErrorToSeverity)
+                .DisposeWith(disposable);
 
-            this.Bind(ViewModel,
-                vm => vm.IsExporting,
-                v => v.Loader.IsVisible
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomHighlightThemeEnabled, v => v.HighlightEnabledToggle.IsChecked)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomHighlightThemeSource, v => v.HighlightFileInput.Text)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.CustomHighlightThemeEnabled, v => v.HighlightFileInput.IsEnabled)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.CustomHighlightThemeEnabled, v => v.HighlightFileButton.IsEnabled)
+                .DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.SearchHighlightThemeSourceCommand, v => v.HighlightFileButton)
+                .DisposeWith(disposable);
 
-            this.OneWayBind(ViewModel,
-                vm => vm.IsExporting,
-                v => v.ExportButton.IsVisible,
-                NotConverter
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.NumberedHeadersEnabled, v => v.HeaderNumberingEnabledToggle.IsChecked)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.TableOfContentEnabled, v => v.ContentTableToggle.IsChecked)
+                .DisposeWith(disposable);
 
-            this.Bind(ViewModel,
-                vm => vm.CustomHighlightThemeEnabled,
-                v => v.HighlightEnabledToggle.IsChecked
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomFontEnabled, v => v.CustomFontEnabledToggle.IsChecked)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.CustomFontEnabled, v => v.CustomFontNameComboBox.IsEnabled)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.InstalledFonts, v => v.CustomFontNameComboBox.ItemsSource)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomFontName, v => v.CustomFontNameComboBox.SelectedItem)
+                .DisposeWith(disposable);
 
-            this.BindCommand(ViewModel,
-                vm => vm.SearchHighlightThemeSourceCommand,
-                v => v.HighlightFileButton
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomMarginEnabled, v => v.CustomMarginEnabledToggle.IsChecked)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomMarginValue, v => v.CustomMarginValueInput.Value,
+                    MarginToValue, ValueToMargin)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.CustomMarginEnabled, v => v.CustomMarginValueInput.IsEnabled)
+                .DisposeWith(disposable);
 
-            this.Bind(ViewModel,
-                vm => vm.CustomHighlightThemeSource,
-                v => v.HighlightFileInput.Text
-            ).DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomPdfEngineEnabled, v => v.PdfEngineToggle.IsChecked)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.SupportedEngine, v => v.PdfEngineCombobox.ItemsSource)
+                .DisposeWith(disposable);
+            this.OneWayBind(ViewModel, vm => vm.CustomPdfEngineEnabled, v => v.PdfEngineCombobox.IsEnabled)
+                .DisposeWith(disposable);
+            this.Bind(ViewModel, vm => vm.CustomPdfEngineValue, v => v.PdfEngineCombobox.SelectedItem)
+                .DisposeWith(disposable);
 
-            this.OneWayBind(ViewModel,
-                vm => vm.CustomHighlightThemeEnabled,
-                v => v.HighlightFileInput.IsEnabled
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.CustomHighlightThemeEnabled,
-                v => v.HighlightFileButton.IsEnabled
-            ).DisposeWith(disposable);
-
-            this.Bind(ViewModel,
-                vm => vm.NumberedHeadersEnabled,
-                v => v.HeaderNumberingEnabledToggle.IsChecked
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomFontEnabled,
-                v => v.CustomFontEnabledToggle.IsChecked
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.CustomFontEnabled,
-                v => v.CustomFontNameComboBox.IsEnabled
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomFontName,
-                v => v.CustomFontNameComboBox.SelectedItem
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.InstalledFonts,
-                v => v.CustomFontNameComboBox.ItemsSource
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomMarginEnabled,
-                v => v.CustomMarginEnabledToggle.IsChecked
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomMarginValue,
-                v => v.CustomMarginValueInput.Value,
-                MarginToValue, ValueToMargin
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.CustomMarginEnabled,
-                v => v.CustomMarginValueInput.IsEnabled
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.SupportedEngine,
-                v => v.PdfEngineCombobox.ItemsSource
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomPdfEngineEnabled,
-                v => v.PdfEngineToggle.IsChecked
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.CustomPdfEngineEnabled,
-                v => v.PdfEngineCombobox.IsEnabled
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.CustomPdfEngineValue,
-                v => v.PdfEngineCombobox.SelectedItem
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.TableOfContentEnabled,
-                v => v.ContentTableToggle.IsChecked
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.Result,
-                v => v.ResultText.Text
-            ).DisposeWith(disposable);
-            this.OneWayBind(ViewModel,
-                vm => vm.IsError,
-                v => v.ResultText.Foreground,
-                ErrorStatusToColor
-            ).DisposeWith(disposable);
-
-            this.BindCommand(ViewModel,
-                vm => vm.OpenLogFolderCommand,
-                v => v.OpenLogFolderMenu
-            ).DisposeWith(disposable);
-            this.Bind(ViewModel,
-                vm => vm.OpenFileOnCompletion,
-                v => v.OpenOnCompletionToggle.IsChecked
-            ).DisposeWith(disposable);
+            this.BindCommand(ViewModel, vm => vm.OpenLogFolderCommand, v => v.OpenLogFolderMenu)
+                .DisposeWith(disposable);
         });
     }
 
-    private IBrush ErrorStatusToColor(bool isError)
+    private void OnDragOver(object? sender, DragEventArgs e)
     {
-        return isError ? Brushes.Red : Brushes.Green;
+        e.DragEffects = e.DataTransfer.Contains(DataFormat.File) ? DragDropEffects.Copy : DragDropEffects.None;
     }
 
-    private bool NotConverter(bool val) => !val;
+    private void OnDrop(object? sender, DragEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        var files = e.DataTransfer.TryGetFiles();
+        var path = files?.OfType<IStorageFile>().FirstOrDefault()?.TryGetLocalPath();
+
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            ViewModel.SourcePath = path;
+        }
+    }
+
+    private FAInfoBarSeverity ErrorToSeverity(bool isError) =>
+        isError ? FAInfoBarSeverity.Error : FAInfoBarSeverity.Success;
+
     private decimal? MarginToValue(decimal value) => value;
     private decimal ValueToMargin(decimal? value) => value ?? 1.3m;
 }

--- a/tests/PandocGui.Tests/MainWindowViewModelTest.cs
+++ b/tests/PandocGui.Tests/MainWindowViewModelTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -248,6 +248,46 @@ public class MainWindowViewModelTest
         Assert.False(viewModel.CustomPdfEngineEnabled);
         Assert.Equal("", viewModel.CustomPdfEngineValue);
         Assert.False(viewModel.TableOfContentEnabled);
+    }
+
+    [Fact]
+    public void HasInput_FollowsWhetherASourcePathIsSet()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        Assert.False(viewModel.HasInput);
+
+        // When
+        viewModel.SourcePath = Path.Combine("documents", "report.md");
+
+        // Then
+        Assert.True(viewModel.HasInput);
+
+        // And when
+        viewModel.SourcePath = "   ";
+
+        // Then
+        Assert.False(viewModel.HasInput);
+    }
+
+    [Fact]
+    public void IsStatusVisible_FollowsWhetherAResultIsSet()
+    {
+        // Given
+        var viewModel = BuildViewModel();
+        Assert.False(viewModel.IsStatusVisible);
+
+        // When
+        viewModel.Result = "Success";
+
+        // Then
+        Assert.True(viewModel.IsStatusVisible);
+
+        // And when
+        viewModel.Result = "";
+
+        // Then
+        Assert.False(viewModel.IsStatusVisible);
     }
 
     [Fact]

--- a/tests/PandocGui.Tests/PandocFormatsTest.cs
+++ b/tests/PandocGui.Tests/PandocFormatsTest.cs
@@ -1,0 +1,22 @@
+using PandocGui.CliWrapper;
+using Xunit;
+
+namespace PandocGui.Tests;
+
+public class PandocFormatsTest
+{
+    [Fact]
+    public void OutputFormat_RendersAsItsDisplayName()
+    {
+        // Given
+        var format = new OutputFormat("PDF", "pdf");
+
+        // When
+        var rendered = format.ToString();
+
+        // Then
+        // The output format combo box binds the records directly, with no item template,
+        // so the ComboBox shows whatever ToString returns.
+        Assert.Equal("PDF", rendered);
+    }
+}


### PR DESCRIPTION
Fourth of thirteen. Rebased on current `main`, so the diff below is this change only.

## What it does

The window now has two states instead of one dense form.

**Empty state** - a drop zone with a document icon, a `Browse…` button and the list of supported inputs. `DragDrop.AllowDrop` is wired on the window, so dropping a file anywhere sets the source path.

**Loaded state** - appears as soon as a source path exists (`HasInput`). `From` and `To` each get a path box, a format combo box and a `Browse…` button; everything that used to sit in three side-by-side expanders now lives behind one `More options` expander. `Convert` is a full-width accent button at the bottom, with `Clear`, `Copy command` and the `Open on completion` toggle beneath it.

Result reporting moved from a coloured `TextBlock` to a `FAInfoBar` driven by `IsStatusVisible`, so success and failure get the standard Fluent styling rather than hand-picked red and green brushes.

## Three supporting fixes

- `OutputFormat.ToString()` returns the display name. The output combo box binds the records directly, so without it the box would show `OutputFormat { DisplayName = PDF, Extension = pdf }`.
- A window-level `ComboBox` style restores the explicit `ItemTemplate` the old markup carried per control. I dropped those templates while rewriting the markup and the format pickers rendered blank - the selection was correct in the view model but nothing was drawn. Caught by running the app, not by the build.
- `Program.Main` is now marked `[STAThread]`. Without it, Windows' `RegisterDragDrop` silently fails and the window never becomes an OLE drop target - dragging a file from Explorer showed the not-allowed cursor no matter what, and `DragOver` never fired. This predates the redesign (`Program.cs` never had the attribute), but this PR is the first to put a feature on top of drag & drop, so it's fixed here. Confirmed with a throwaway diagnostic log: zero `DragOver` calls before the fix, `DragOver` firing with `Formats` containing `Universal: File` and `DragEffects` resolving to `Copy` after it.

## Verification

- `dotnet test PandocGui.sln -c Release` - 49 passed, 0 failed, 259 ms.
- Ran the app on Windows and stepped through both states: empty state renders the drop zone; after picking a `.md` file the form appears with `markdown` and `PDF` selected and visible in the combo boxes.
- **Drag & drop confirmed working by hand**: dragging a `.docx` from File Explorer onto the drop zone now sets the source path, both before and after a clean rebuild.
- The three view-model/format behaviours are pinned by tests that were confirmed to fail when the production code is mutated. The `[STAThread]` fix has no unit test - apartment state isn't observable without a real Win32 message pump; verified by hand instead.

## Deliberately left out

- **No unit test for the drag & drop handler or for the view bindings.** `MainWindow.axaml.cs` needs a UI test harness the project does not have; verified by running the app instead.
- **`Convert` is no longer hidden while exporting**, only covered by the progress ring. `ReactiveCommand` already blocks re-entry, so this is a visual choice - say the word if you would rather keep the button hidden.
